### PR TITLE
Remove mention for left, kick, ban and unban & updated readme

### DIFF
--- a/logger/README.md
+++ b/logger/README.md
@@ -15,5 +15,6 @@ The commands usage list assumes you retain the default prefix, `?`.
 | Permission level | Usage | Function | Note |
 |------------------|-------|----------|------|
 | ADMINISTRATOR [4] | `?logger channel #channel` | Sets the channel for the log messages. | Has to be a channel in Modmail's functioning guild (destined by `GUILD_ID`). |
+| ADMINISTRATOR [4] | `?logger log-bot` | Toggle whether to log bot activities. | Defaults to no. |
 | ADMINISTRATOR [4] | `?logger log-modmail` | Toggle whether to log Modmail bot messages. | Defaults to yes. |
 | ADMINISTRATOR [4] | `?logger whitelist #channel` | Toggle whether to log a channel. | Can be either channel. |

--- a/logger/logger.py
+++ b/logger/logger.py
@@ -642,7 +642,7 @@ class Logger(commands.Cog):
             return
         await channel.send(embed=self.make_embed(
             'Member Left',
-            f'{member.mention} has left.'
+            f'{member} has left.'
         ))
 
     def make_embed(self, title, description='', *, time=None, fields=None, footer=None):

--- a/logger/logger.py
+++ b/logger/logger.py
@@ -334,7 +334,7 @@ class Logger(commands.Cog):
             elif audit.action == AuditLogAction.kick:
                 await channel.send(embed=self.make_embed(
                     f'Member Kicked',
-                    f'{audit.target.mention} has been kicked by {audit.user.mention}.',
+                    f'{audit.target} has been kicked by {audit.user.mention}.',
                     time=audit.created_at,
                     fields=[('Reason:', escape(audit.reason) or 'No Reason', False)]
                 ))
@@ -350,7 +350,7 @@ class Logger(commands.Cog):
             elif audit.action == AuditLogAction.ban:
                 await channel.send(embed=self.make_embed(
                     f'Member Banned',
-                    f'{audit.target.mention} has been banned by {audit.user.mention}.',
+                    f'{audit.target} has been banned by {audit.user.mention}.',
                     time=audit.created_at,
                     fields=[('Reason:', escape(audit.reason) or 'No Reason', False)]
                 ))
@@ -358,7 +358,7 @@ class Logger(commands.Cog):
             elif audit.action == AuditLogAction.unban:
                 await channel.send(embed=self.make_embed(
                     f'Member Unbanned',
-                    f'{audit.target.mention} has been unbanned by {audit.user.mention}.',
+                    f'{audit.target} has been unbanned by {audit.user.mention}.',
                     time=audit.created_at
                 ))
 


### PR DESCRIPTION
I've removed the user mention for Member Left, Member Kicked, Member Banned and Member Unbanned messages as the user won't be in the server then and Discord can't show the mention properly if you're not in any mutual servers.

I've also updated the readme with the `log-bot` command.